### PR TITLE
Fix for multiplayer

### DIFF
--- a/scripts/nixie_tube.lua
+++ b/scripts/nixie_tube.lua
@@ -554,6 +554,7 @@ script.on_init(function ()
     script.on_event(defines.events.on_entity_died, on_object_destroyed)
     script.on_event(defines.events.on_player_mined_entity, on_object_destroyed)
     script.on_event(defines.events.on_robot_mined_entity, on_object_destroyed)
+	script.on_event(defines.events.on_space_platform_mined_entity, on_object_destroyed)
     script.on_event(defines.events.script_raised_destroy, on_object_destroyed)
 end)
 


### PR DESCRIPTION
Fixes the below error allowing this to be used in multiplayer

50.576 Error ClientMultiplayerManager.cpp:1079: mod-UPSFriendlyNixieTubeDisplay was not registered for the following events when the map was saved but has registered them as a result of loading: on_space_platform_mined_entity (ID 75)
  50.576 Error ClientMultiplayerManager.cpp:86: MultiplayerManager failed: "" + multiplayer.script-event-mismatch + "
" + "
mod-UPSFriendlyNixieTubeDisplay"